### PR TITLE
Use separate bolt density

### DIFF
--- a/pbsm/models/CompositeTestObject/GenerateObjectConfiguration.py
+++ b/pbsm/models/CompositeTestObject/GenerateObjectConfiguration.py
@@ -120,6 +120,7 @@ class CompositeTestObject:
         PLA_struct_density  = 491  #Assumes a 20% infill
         ABS_density         = 1321
         steel_density       = 7847  
+        bolt_density        = 6730
 
         #Initially, we assume that the whole body is filled with plastic.
         mm_to_m = 1e-3
@@ -191,7 +192,7 @@ class CompositeTestObject:
 
         #Add bolts
         for bolt in bolts_attached:
-            i = cylinder_inertia([b_r,b_h], steel_density, com_pose(0,0,0, bolt_pos[bolt]))
+            i = cylinder_inertia([b_r,b_h], bolt_density, com_pose(0,0,0, bolt_pos[bolt]))
             primitives.append(i)
 
         #Add steel weights


### PR DESCRIPTION
This doesn't really make a difference, but it seems like the right thing to do. This is based on the linked bolts in the README.

Before:
```
python3 GenerateObjectConfiguration.py -b 0 14 -s 0 1 2 3 4 -o test.urdf --print
test.urdf
Total Mass:      1.1718997410246232
Center of Mass:  [0.0000000000 0.0409352866 0.0250000000]
Inertia Tensor wrt. origin, about COM:
 [[0.0171855735 0.0000000000 0.0000000000]
 [0.0000000000 0.0040224473 -0.0023986026]
 [0.0000000000 -0.0023986026 0.0179134108]]
```

After:
```
python3 GenerateObjectConfiguration.py -b 0 14 -s 0 1 2 3 4 -o test.urdf --print
test.urdf
Total Mass:      1.1680782668800922
Center of Mass:  [0.0000000000 0.0410692101 0.0250000000]
Inertia Tensor wrt. origin, about COM:
 [[0.0171004315 0.0000000000 0.0000000000]
 [0.0000000000 0.0040168639 -0.0023986026]
 [0.0000000000 -0.0023986026 0.0178338314]]
```